### PR TITLE
Add iOS 8 Category Support

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -12,6 +12,7 @@ type Payload struct {
 	//alert text, may be truncated if bigger than max payload size
 	AlertText        string
 	Badge            int
+	Category         string
 	ContentAvailable int
 	//any custom fields to be added to the apns payload
 	CustomFields map[string]interface{}
@@ -42,6 +43,7 @@ type alertBodyAps struct {
 	Alert            apsAlertBody `json:"alert,omitempty"`
 	Badge            int          `json:"badge,omitempty"`
 	Sound            string       `json:"sound,omitempty"`
+	Category         string       `json:"category,omitempty"`
 	ContentAvailable int          `json:"content-available,omitempty"`
 }
 
@@ -49,6 +51,7 @@ type simpleAps struct {
 	Alert            string `json:"alert,omitempty"`
 	Badge            int    `json:"badge,omitempty"`
 	Sound            string `json:"sound,omitempty"`
+	Category         string `json:"category,omitempty"`
 	ContentAvailable int    `json:"content-available,omitempty"`
 }
 
@@ -111,6 +114,7 @@ func (p *Payload) marshalSimplePayload(maxPayloadSize int) ([]byte, error) {
 		Alert:            p.AlertText,
 		Badge:            p.Badge,
 		Sound:            p.Sound,
+		Category:         p.Category,
 		ContentAvailable: p.ContentAvailable,
 	}
 
@@ -164,6 +168,7 @@ func (p *Payload) marshalAlertBodyPayload(maxPayloadSize int) ([]byte, error) {
 		Alert:            alertBody,
 		Badge:            p.Badge,
 		Sound:            p.Sound,
+		Category:         p.Category,
 		ContentAvailable: p.ContentAvailable,
 	}
 

--- a/payload_test.go
+++ b/payload_test.go
@@ -11,6 +11,7 @@ func TestSimpleMarshal(t *testing.T) {
 		Badge:            2,
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
+		Category:         "TEST_CATEGORY",
 	}
 
 	payloadSize := 256
@@ -24,7 +25,7 @@ func TestSimpleMarshal(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
 	}
@@ -182,6 +183,7 @@ func TestAlertBodyMarshal(t *testing.T) {
 		AlertText:        "Testing this payload",
 		Badge:            2,
 		ContentAvailable: 1,
+		Category:         "TEST_CATEGORY",
 		Sound:            "test.aiff",
 		ActionLocKey:     "act-loc-key",
 		LocKey:           "loc-key",
@@ -200,9 +202,9 @@ func TestAlertBodyMarshal(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\",\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\",\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 

--- a/payload_test.go
+++ b/payload_test.go
@@ -27,7 +27,7 @@ func TestSimpleMarshal(t *testing.T) {
 
 	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 


### PR DESCRIPTION
This adds support for the new "category" field in aps payloads.

More information here:
http://docs.urbanairship.com/whats-new/july-2014-release.html#notification-actions-category-api-support