### PR TITLE
Reset tls deadline after handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ GatewayHost                     string                  //apple gateway, default
 GatewayPort                     string                  //apple gateway port, defaults to "2195"
 MaxOutboundTCPFrameSize         int                     //max number of bytes to frame data to, defaults to TCP_FRAME_MAX
                                                         //generally best to NOT set this and use the default
-SocketTimeout                   int                     //number of seconds to wait before bailing on a socket connection
-TlsTimeout                      int                     //number of seconds to wait before bailing on a tls handshake
+SocketTimeout                   int                     //number of seconds to wait before bailing on a socket connection, defaults to no timeout
+TlsTimeout                      int                     //number of seconds to wait before bailing on a tls handshake, defaults to no timeout
 ```
 
 #License

--- a/connection.go
+++ b/connection.go
@@ -34,9 +34,9 @@ type APNSConfig struct {
 	//max number of bytes to frame data to, defaults to TCP_FRAME_MAX
 	//generally best to NOT set this and use the default
 	MaxOutboundTCPFrameSize int
-	//number of seconds to wait for connection before bailing, defaults to 5 seconds
+	//number of seconds to wait for connection before bailing, defaults to no timeout
 	SocketTimeout int
-	//number of seconds to wait for Tls handshake to complete before bailing, defaults to 5 seconds
+	//number of seconds to wait for Tls handshake to complete before bailing, defaults to no timeout
 	TlsTimeout int
 }
 
@@ -154,12 +154,6 @@ func NewAPNSConnection(config *APNSConfig) (*APNSConnection, error) {
 	}
 	if config.MaxPayloadSize == 0 {
 		config.MaxPayloadSize = 256
-	}
-	if config.SocketTimeout == 0 {
-		config.SocketTimeout = 5
-	}
-	if config.TlsTimeout == 0 {
-		config.TlsTimeout = 5
 	}
 
 	x509Cert, err := tls.X509KeyPair(config.CertificateBytes, config.KeyBytes)

--- a/connection.go
+++ b/connection.go
@@ -182,7 +182,7 @@ func NewAPNSConnection(config *APNSConfig) (*APNSConnection, error) {
 	}
 
 	tlsSocket := tls.Client(tcpSocket, tlsConf)
-	tlsSocket.SetWriteDeadline(time.Now().Add(time.Duration(config.TlsTimeout) * time.Second))
+	tlsSocket.SetDeadline(time.Now().Add(time.Duration(config.TlsTimeout) * time.Second))
 	err = tlsSocket.Handshake()
 	if err != nil {
 		//failed to handshake with tls information
@@ -190,6 +190,8 @@ func NewAPNSConnection(config *APNSConfig) (*APNSConnection, error) {
 	}
 
 	//hooray! we're connected
+	//reset the deadline so it doesn't fail subsequent writes
+	tlsSocket.SetDeadline(time.Time{})
 
 	return socketAPNSConnection(tlsSocket, config), nil
 }


### PR DESCRIPTION
Lots of discussion here via @justinrosenthal https://github.com/joekarl/go-libapns/commit/b291a56dba78b28446d75de393ddaa0c6f15ab3e#commitcomment-9307266

Essentially just unbreaks the lib by resetting the tls deadline after a successful handshake.