### PR TITLE
Alternative method to allowing 0 values for badge number while respecting "omitempty"

### DIFF
--- a/badge_number.go
+++ b/badge_number.go
@@ -5,24 +5,34 @@ import (
 	"strconv"
 )
 
+// Struct representing the badge number over
+// the app icon on iOS
 type BadgeNumber struct {
 	number int
 	set    bool
 }
 
+// Returns the set badge number
 func (b *BadgeNumber) Number() int {
 	return b.number
 }
 
+// Returns whether or not this BadgeNumber
+// is set and should be sent in the APNS payload
 func (b *BadgeNumber) IsSet() bool {
 	return b.set
 }
 
+// Resets the BadgeNumber to 0 and
+// removes it from the APNS payload
 func (b *BadgeNumber) UnSet() {
 	b.number = 0
 	b.set = false
 }
 
+// Sets the badge number and includes it in the
+// payload to APNS. call .Set(0) to have the badge
+// number cleared from the app icon
 func (b *BadgeNumber) Set(number int) error {
 	if number < 0 {
 		return errors.New("Number must be >= 0")
@@ -55,6 +65,8 @@ func (b *BadgeNumber) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Get a new badge number, set to the initial
+// number, and included in the payload
 func NewBadgeNumber(number int) BadgeNumber {
 	return BadgeNumber{
 		number: number,

--- a/badge_number.go
+++ b/badge_number.go
@@ -1,0 +1,63 @@
+package apns
+
+import (
+	"errors"
+	"strconv"
+)
+
+type BadgeNumber struct {
+	number int
+	set    bool
+}
+
+func (b *BadgeNumber) Number() int {
+	return b.number
+}
+
+func (b *BadgeNumber) IsSet() bool {
+	return b.set
+}
+
+func (b *BadgeNumber) UnSet() {
+	b.number = 0
+	b.set = false
+}
+
+func (b *BadgeNumber) Set(number int) error {
+	if number < 0 {
+		return errors.New("Number must be >= 0")
+	}
+
+	b.number = number
+	b.set = true
+	return nil
+}
+
+func (b BadgeNumber) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(b.number)), nil
+}
+
+func (b *BadgeNumber) UnmarshalJSON(data []byte) error {
+	val, err := strconv.ParseInt(string(data), 10, 32)
+	if err != nil {
+		return errors.New("Error unmarshalling BadgeNumber, cannot convert []byte to int32")
+	}
+
+	// Since the point of this type is to
+	// allow proper inclusion of 0 for int
+	// types while respecting omitempty,
+	// assume that set==true if there is
+	// a value to unmarshal
+	*b = BadgeNumber{
+		number: int(val),
+		set:    true,
+	}
+	return nil
+}
+
+func NewBadgeNumber(number int) BadgeNumber {
+	return BadgeNumber{
+		number: number,
+		set:    true,
+	}
+}

--- a/badge_number_test.go
+++ b/badge_number_test.go
@@ -1,0 +1,86 @@
+package apns
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBadgeNumberDefaults(t *testing.T) {
+	b := BadgeNumber{}
+
+	if b.IsSet() {
+		t.Error("BadgeNumber should not be set by default")
+	}
+	if b.Number() != 0 {
+		t.Error("Badge number should be 0 by default")
+	}
+}
+
+func TestBadgeNumberNew(t *testing.T) {
+	b := NewBadgeNumber(5)
+
+	if !b.IsSet() {
+		t.Error("NewBadgeNumber should return set BadgeNumber")
+	}
+	if b.Number() != 5 {
+		t.Error("Resulting badge number should be 5")
+	}
+}
+
+func TestBadgeNumberUnset(t *testing.T) {
+	b := NewBadgeNumber(5)
+
+	if !b.IsSet() {
+		t.Error("NewBadgeNumber should return set BadgeNumber")
+	}
+
+	b.UnSet()
+
+	if b.IsSet() {
+		t.Error("UnSet should unset BadgeNumber")
+	}
+	if b.Number() != 0 {
+		t.Error("UnSet should set number to 0")
+	}
+}
+
+func TestBadgeNumberMarshalJSON(t *testing.T) {
+	b := NewBadgeNumber(11)
+	m := map[string]BadgeNumber{
+		"number": b,
+	}
+
+	jsonData, err := json.Marshal(m)
+	if err != nil {
+		t.Errorf("Error marshalling BadgeNumber: %s", err.Error())
+	}
+
+	expected := "{\"number\":11}"
+	if string(jsonData) != expected {
+		t.Errorf(
+			"JSON output\n%s\ndoes not match\n%s",
+			string(jsonData),
+			expected,
+		)
+	}
+}
+
+func TestBadgeNumberUnmarshalJSON(t *testing.T) {
+	type TestStruct struct {
+		Number BadgeNumber
+	}
+
+	var ts TestStruct
+	jsonStr := "{\"number\":11}"
+	err := json.Unmarshal([]byte(jsonStr), &ts)
+	if err != nil {
+		t.Errorf("Error unmarshalling to BadgeNumber: %s", err.Error())
+	}
+
+	if !ts.Number.IsSet() {
+		t.Error("Resulting BadgeNumber should be set")
+	}
+	if ts.Number.Number() != 11 {
+		t.Error("Expected number to be 11, got %d", ts.Number.Number())
+	}
+}

--- a/payload.go
+++ b/payload.go
@@ -194,7 +194,7 @@ func (p *Payload) marshalAlertBodyPayload(maxPayloadSize int) ([]byte, error) {
 }
 
 func (s simpleAps) MarshalJSON() ([]byte, error) {
-	toMarshal := map[string]interface{}{}
+	toMarshal := make(map[string]interface{})
 
 	if s.Alert != "" {
 		toMarshal["alert"] = s.Alert
@@ -216,7 +216,7 @@ func (s simpleAps) MarshalJSON() ([]byte, error) {
 }
 
 func (a alertBodyAps) MarshalJSON() ([]byte, error) {
-	toMarshal := map[string]interface{}{}
+	toMarshal := make(map[string]interface{})
 	toMarshal["alert"] = a.Alert
 
 	if a.Badge.IsSet() {

--- a/payload.go
+++ b/payload.go
@@ -11,12 +11,7 @@ type Payload struct {
 	ActionLocKey string
 	//alert text, may be truncated if bigger than max payload size
 	AlertText string
-	//number to set the badge to
-	//*Note this is lame but has to be handled this way
-	//because badge of 0 will be omitted from the final json
-	//if set to 0 will not send a badge number
-	//if set to > 0 will set the badge number
-	//if set to < 0 will clear the current badge number
+	// Number to set the badge number to of the app icon
 	Badge            BadgeNumber
 	Category         string
 	ContentAvailable int

--- a/payload_test.go
+++ b/payload_test.go
@@ -8,7 +8,7 @@ import (
 func TestSimpleMarshal(t *testing.T) {
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		Category:         "TEST_CATEGORY",
@@ -25,7 +25,7 @@ func TestSimpleMarshal(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"category\":\"TEST_CATEGORY\",\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
@@ -34,7 +34,6 @@ func TestSimpleMarshal(t *testing.T) {
 func TestBadge0ShouldOmitBadge(t *testing.T) {
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            0,
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		Category:         "TEST_CATEGORY",
@@ -51,33 +50,7 @@ func TestBadge0ShouldOmitBadge(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
-	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
-	}
-}
-
-func TestBadgeLessThan0ShouldBadgeMinus1(t *testing.T) {
-	p := Payload{
-		AlertText:        "Testing this payload",
-		Badge:            -5,
-		ContentAvailable: 1,
-		Sound:            "test.aiff",
-		Category:         "TEST_CATEGORY",
-	}
-
-	payloadSize := 256
-
-	json, err := p.Marshal(payloadSize)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(json) > payloadSize {
-		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
-	}
-
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":-1,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"category\":\"TEST_CATEGORY\",\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
@@ -96,7 +69,7 @@ func TestSimpleMarshalWithCustomFields(t *testing.T) {
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -113,7 +86,7 @@ func TestSimpleMarshalWithCustomFields(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1},\"arr\":[\"a\",2],\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"},\"arr\":[\"a\",2],\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
 	}
@@ -124,7 +97,7 @@ func TestSimpleMarshalTruncate(t *testing.T) {
 		AlertText: "Testing this payload with a really long message that should " +
 			"cause the payload to be truncated yay and stuff blah blah blah blah blah blah " +
 			"and some more text to really make this much bigger and stuff",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 	}
@@ -140,7 +113,7 @@ func TestSimpleMarshalTruncate(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and some more text to really make this much...\",\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and some more text to really make this much...\",\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
 	}
@@ -161,7 +134,7 @@ func TestSimpleMarshalTruncateWithCustomFields(t *testing.T) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -179,7 +152,7 @@ func TestSimpleMarshalTruncateWithCustomFields(t *testing.T) {
 	}
 
 	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload with a bunch of text that should get truncated " +
-		"so truncate this already please yes thank you...\",\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}," +
+		"so truncate this already please yes thank you...\",\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}," +
 		"\"arr\":[\"a\",2],\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
@@ -216,7 +189,7 @@ func TestSimpleMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T) {
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -233,7 +206,7 @@ func TestSimpleMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T) {
 func TestAlertBodyMarshal(t *testing.T) {
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Category:         "TEST_CATEGORY",
 		Sound:            "test.aiff",
@@ -254,7 +227,7 @@ func TestAlertBodyMarshal(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\",\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\",\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"category\":\"TEST_CATEGORY\",\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
@@ -273,7 +246,7 @@ func TestAlertBodyMarshalWithCustomFields(t *testing.T) {
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -295,11 +268,11 @@ func TestAlertBodyMarshalWithCustomFields(t *testing.T) {
 
 	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\"," +
 		"\"launch-image\":\"launch.png\"}," +
-		"\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1},\"arr\":[\"a\",2]," +
+		"\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"},\"arr\":[\"a\",2]," +
 		"\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
 
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 
@@ -308,7 +281,7 @@ func TestAlertBodyMarshalTruncate(t *testing.T) {
 		AlertText: "Testing this payload with a really long message that should " +
 			"cause the payload to be truncated yay and stuff blah blah blah blah blah blah " +
 			"and some more text to really make this much bigger and stuff",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		LaunchImage:      "launch.png",
@@ -325,9 +298,9 @@ func TestAlertBodyMarshalTruncate(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and so...\",\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and so...\",\"launch-image\":\"launch.png\"},\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 
@@ -343,7 +316,7 @@ func TestAlertBodyMarshalTruncateWithCustomFields(t *testing.T) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -365,10 +338,10 @@ func TestAlertBodyMarshalTruncateWithCustomFields(t *testing.T) {
 	}
 
 	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this ...\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\"," +
-		"\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}," +
+		"\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}," +
 		"\"arr\":[\"a\",2],\"arr2\":[\"a\",2],\"num\":55,\"str\":\"string\"}"
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 
@@ -402,7 +375,7 @@ func TestAlertBodyMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T)
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -432,7 +405,7 @@ func BenchmarkSimpleMarshalTruncate256WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -459,7 +432,7 @@ func BenchmarkSimpleMarshalTruncate1024WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -486,7 +459,7 @@ func BenchmarkAlertBodyMarshalTruncate256WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -514,7 +487,7 @@ func BenchmarkAlertBodyMarshalTruncate1024WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,


### PR DESCRIPTION
Alternative to #6. Benefits:

- Not using int pointer, so pass-by-value is share-none (removes race conditions across goroutines)
- BadgeNumber satisfies the [json.Unmarshaler](http://golang.org/pkg/encoding/json/#Unmarshaler) and [json.Marshaler](http://golang.org/pkg/encoding/json/#Marshaler) interfaces
- Method to unset badge number once set

Types `simpleAps` and `alertBodyAps` have been given [json.Unmarshaler](http://golang.org/pkg/encoding/json/#Unmarshaler) interface methods which allow them to be more picky about field inclusion.

Potential downsides:
- `simpleAps` and `alertBodyAps` would need custom unmarshal fields if we ever needed to deserialize JSON to these types
- `map[string]interface{}` maps used in `MarshalJSON` methods
- Breaking change

The main reason I went with this approach is so I can pass-by-value `Payload` structs without the copies sharing pointers to the same value in memory.