### PR TITLE
Update for iOS 8.2 fields and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ Apple specifies that you should connect to the feedback service gateway regularl
 
 
 ##Push Notification Length
-Apple places a strict limit on push notification length (currently at 256 bytes). go-libapns will attempt to fit your push notification into that size limit by first applying all of your supplied custom fields and applying as much of your alert text as possible. This truncation is not without cost as it takes almost twice the time to fix a message that is too long. So if possible, try to find a sweet spot that won't cause truncation to occur. If unable to truncate the message, go-libapns will close it's connection to the APNS gateway (you've been warned). This limit is configurable in the APNSConfig object.
+Apple places a strict limit on push notification length (currently at 2048 bytes). go-libapns will attempt to fit your push notification into that size limit by first applying all of your supplied custom fields and applying as much of your alert text as possible. This truncation is not without cost as it takes almost twice the time to fix a message that is too long. So if possible, try to find a sweet spot that won't cause truncation to occur. If unable to truncate the message, go-libapns will close it's connection to the APNS gateway (you've been warned). This limit is configurable in the APNSConfig object.
+
+_Note: Prior to iOS 8, the limit was 256 bytes. APNS will accept and deliver up to 2048 bytes to devices 
+running iOS 8 as well as those running on older versions of iOS._
 
 ##TCP Framing
 Most APNS libraries rely on the OS Nagling to buffer data into the socket. go-libapns does not rely on Nagling but does do what it can to optimize the number of bytes sent per TCP frame. The two relevant config options that control this behavior are:
@@ -101,7 +104,7 @@ The other fields all have sane defaults
 ```go
 InFlightPayloadBufferSize       int                     //number of payloads to keep for error purposes, defaults to 10000
 FramingTimeout                  int                     //number of milliseconds between frame flushes, defaults to 10ms
-MaxPayloadSize                  int                     //max number of bytes allowed in payload, defaults to 256
+MaxPayloadSize                  int                     //max number of bytes allowed in payload, defaults to 2048
 CertificateBytes                []byte                  //bytes for cert.pem : required
 KeyBytes                        []byte                  //bytes for key.pem : required
 GatewayHost                     string                  //apple gateway, defaults to "gateway.push.apple.com"

--- a/badge_number.go
+++ b/badge_number.go
@@ -5,24 +5,34 @@ import (
 	"strconv"
 )
 
+// Struct representing the badge number over
+// the app icon on iOS
 type BadgeNumber struct {
 	number int
 	set    bool
 }
 
+// Returns the set badge number
 func (b *BadgeNumber) Number() int {
 	return b.number
 }
 
+// Returns whether or not this BadgeNumber
+// is set and should be sent in the APNS payload
 func (b *BadgeNumber) IsSet() bool {
 	return b.set
 }
 
+// Resets the BadgeNumber to 0 and
+// removes it from the APNS payload
 func (b *BadgeNumber) UnSet() {
 	b.number = 0
 	b.set = false
 }
 
+// Sets the badge number and includes it in the
+// payload to APNS. call .Set(0) to have the badge
+// number cleared from the app icon
 func (b *BadgeNumber) Set(number int) error {
 	if number < 0 {
 		return errors.New("Number must be >= 0")
@@ -55,6 +65,8 @@ func (b *BadgeNumber) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Get a new badge number, set to the initial
+// number, and included in the payload
 func NewBadgeNumber(number int) BadgeNumber {
 	return BadgeNumber{
 		number: number,

--- a/badge_number.go
+++ b/badge_number.go
@@ -1,0 +1,63 @@
+package apns
+
+import (
+	"errors"
+	"strconv"
+)
+
+type BadgeNumber struct {
+	number int
+	set    bool
+}
+
+func (b *BadgeNumber) Number() int {
+	return b.number
+}
+
+func (b *BadgeNumber) IsSet() bool {
+	return b.set
+}
+
+func (b *BadgeNumber) UnSet() {
+	b.number = 0
+	b.set = false
+}
+
+func (b *BadgeNumber) Set(number int) error {
+	if number < 0 {
+		return errors.New("Number must be >= 0")
+	}
+
+	b.number = number
+	b.set = true
+	return nil
+}
+
+func (b BadgeNumber) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(b.number)), nil
+}
+
+func (b *BadgeNumber) UnmarshalJSON(data []byte) error {
+	val, err := strconv.ParseInt(string(data), 10, 32)
+	if err != nil {
+		return errors.New("Error unmarshalling BadgeNumber, cannot convert []byte to int32")
+	}
+
+	// Since the point of this type is to
+	// allow proper inclusion of 0 for int
+	// types while respecting omitempty,
+	// assume that set==true if there is
+	// a value to unmarshal
+	*b = BadgeNumber{
+		number: int(val),
+		set:    true,
+	}
+	return nil
+}
+
+func NewBadgeNumber(number int) BadgeNumber {
+	return BadgeNumber{
+		number: number,
+		set:    true,
+	}
+}

--- a/badge_number_test.go
+++ b/badge_number_test.go
@@ -1,0 +1,86 @@
+package apns
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBadgeNumberDefaults(t *testing.T) {
+	b := BadgeNumber{}
+
+	if b.IsSet() {
+		t.Error("BadgeNumber should not be set by default")
+	}
+	if b.Number() != 0 {
+		t.Error("Badge number should be 0 by default")
+	}
+}
+
+func TestBadgeNumberNew(t *testing.T) {
+	b := NewBadgeNumber(5)
+
+	if !b.IsSet() {
+		t.Error("NewBadgeNumber should return set BadgeNumber")
+	}
+	if b.Number() != 5 {
+		t.Error("Resulting badge number should be 5")
+	}
+}
+
+func TestBadgeNumberUnset(t *testing.T) {
+	b := NewBadgeNumber(5)
+
+	if !b.IsSet() {
+		t.Error("NewBadgeNumber should return set BadgeNumber")
+	}
+
+	b.UnSet()
+
+	if b.IsSet() {
+		t.Error("UnSet should unset BadgeNumber")
+	}
+	if b.Number() != 0 {
+		t.Error("UnSet should set number to 0")
+	}
+}
+
+func TestBadgeNumberMarshalJSON(t *testing.T) {
+	b := NewBadgeNumber(11)
+	m := map[string]BadgeNumber{
+		"number": b,
+	}
+
+	jsonData, err := json.Marshal(m)
+	if err != nil {
+		t.Errorf("Error marshalling BadgeNumber: %s", err.Error())
+	}
+
+	expected := "{\"number\":11}"
+	if string(jsonData) != expected {
+		t.Errorf(
+			"JSON output\n%s\ndoes not match\n%s",
+			string(jsonData),
+			expected,
+		)
+	}
+}
+
+func TestBadgeNumberUnmarshalJSON(t *testing.T) {
+	type TestStruct struct {
+		Number BadgeNumber
+	}
+
+	var ts TestStruct
+	jsonStr := "{\"number\":11}"
+	err := json.Unmarshal([]byte(jsonStr), &ts)
+	if err != nil {
+		t.Errorf("Error unmarshalling to BadgeNumber: %s", err.Error())
+	}
+
+	if !ts.Number.IsSet() {
+		t.Error("Resulting BadgeNumber should be set")
+	}
+	if ts.Number.Number() != 11 {
+		t.Error("Expected number to be 11, got %d", ts.Number.Number())
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -21,7 +21,7 @@ type APNSConfig struct {
 	InFlightPayloadBufferSize int
 	//number of milliseconds between frame flushes, defaults to 10
 	FramingTimeout int
-	//max number of bytes allowed in payload, defaults to 256
+	//max number of bytes allowed in payload, defaults to 2048
 	MaxPayloadSize int
 	//bytes for cert.pem : required
 	CertificateBytes []byte
@@ -127,7 +127,7 @@ func NewAPNSConnection(config *APNSConfig) (*APNSConnection, error) {
 		errorStrs += "Invalid InFlightPayloadBufferSize. Should be > 0 (and probably around 10000)\n"
 	}
 	if config.MaxOutboundTCPFrameSize < 0 || config.MaxOutboundTCPFrameSize > TCP_FRAME_MAX {
-		errorStrs += "Invalid MaxOutboundTCPFrameSize. Should be between 0 and TCP_FRAME_MAX (and probably above 256)\n"
+		errorStrs += "Invalid MaxOutboundTCPFrameSize. Should be between 0 and TCP_FRAME_MAX (and probably above 2048)\n"
 	}
 	if config.MaxPayloadSize < 0 {
 		errorStrs += "Invalid MaxPayloadSize. Should be greater than 0.\n"
@@ -153,7 +153,7 @@ func NewAPNSConnection(config *APNSConfig) (*APNSConnection, error) {
 		config.GatewayHost = "gateway.push.apple.com"
 	}
 	if config.MaxPayloadSize == 0 {
-		config.MaxPayloadSize = 256
+		config.MaxPayloadSize = 2048
 	}
 	if config.TlsTimeout == 0 {
 		config.TlsTimeout = 5

--- a/connection_test.go
+++ b/connection_test.go
@@ -57,7 +57,7 @@ func TestConnectionShouldCloseOnWriteError(t *testing.T) {
 			InFlightPayloadBufferSize: 10000,
 			FramingTimeout:            10,
 			MaxOutboundTCPFrameSize:   TCP_FRAME_MAX,
-			MaxPayloadSize:            256,
+			MaxPayloadSize:            2048,
 		})
 
 	payload := &Payload{
@@ -127,7 +127,7 @@ func TestConnectionShouldCloseOnReadError(t *testing.T) {
 				InFlightPayloadBufferSize: 10000,
 				FramingTimeout:            10,
 				MaxOutboundTCPFrameSize:   TCP_FRAME_MAX,
-				MaxPayloadSize:            256,
+				MaxPayloadSize:            2048,
 			})
 
 		for {
@@ -204,7 +204,7 @@ func TestConnectionShouldCloseOnAppleResponse(t *testing.T) {
 			InFlightPayloadBufferSize: 10000,
 			FramingTimeout:            10,
 			MaxOutboundTCPFrameSize:   TCP_FRAME_MAX,
-			MaxPayloadSize:            256,
+			MaxPayloadSize:            2048,
 		})
 
 	token := "4ec500020d8350072d2417ba566feda10b2b266558371a65ba67fede21393c8f"
@@ -316,7 +316,7 @@ func TestConnectionShouldCloseAndReturnUnsentOnAppleResponse(t *testing.T) {
 				InFlightPayloadBufferSize: 10000,
 				FramingTimeout:            10,
 				MaxOutboundTCPFrameSize:   TCP_FRAME_MAX,
-				MaxPayloadSize:            256,
+				MaxPayloadSize:            2048,
 			})
 
 		for {
@@ -466,7 +466,7 @@ func TestConnectionShouldCloseAndReturnUnsentUpToBufferSizeOnAppleResponse(t *te
 				InFlightPayloadBufferSize: 1,
 				FramingTimeout:            10,
 				MaxOutboundTCPFrameSize:   TCP_FRAME_MAX,
-				MaxPayloadSize:            256,
+				MaxPayloadSize:            2048,
 			})
 
 		for {

--- a/payload.go
+++ b/payload.go
@@ -194,7 +194,7 @@ func (p *Payload) marshalAlertBodyPayload(maxPayloadSize int) ([]byte, error) {
 }
 
 func (s simpleAps) MarshalJSON() ([]byte, error) {
-	toMarshal := map[string]interface{}{}
+	toMarshal := make(map[string]interface{})
 
 	if s.Alert != "" {
 		toMarshal["alert"] = s.Alert
@@ -216,7 +216,7 @@ func (s simpleAps) MarshalJSON() ([]byte, error) {
 }
 
 func (a alertBodyAps) MarshalJSON() ([]byte, error) {
-	toMarshal := map[string]interface{}{}
+	toMarshal := make(map[string]interface{})
 	toMarshal["alert"] = a.Alert
 
 	if a.Badge.IsSet() {

--- a/payload.go
+++ b/payload.go
@@ -11,12 +11,7 @@ type Payload struct {
 	ActionLocKey string
 	//alert text, may be truncated if bigger than max payload size
 	AlertText string
-	//number to set the badge to
-	//*Note this is lame but has to be handled this way
-	//because badge of 0 will be omitted from the final json
-	//if set to 0 will not send a badge number
-	//if set to > 0 will set the badge number
-	//if set to < 0 will clear the current badge number
+	// Number to set the badge number to of the app icon
 	Badge            BadgeNumber
 	Category         string
 	ContentAvailable int

--- a/payload_test.go
+++ b/payload_test.go
@@ -205,15 +205,17 @@ func TestSimpleMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T) {
 
 func TestAlertBodyMarshal(t *testing.T) {
 	p := Payload{
-		AlertText:        "Testing this payload",
 		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Category:         "TEST_CATEGORY",
 		Sound:            "test.aiff",
-		ActionLocKey:     "act-loc-key",
-		LocKey:           "loc-key",
-		LocArgs:          []string{"arg1", "arg2"},
-		LaunchImage:      "launch.png",
+		AlertBody: APSAlertBody{
+			Body:         "Testing this payload",
+			ActionLocKey: "act-loc-key",
+			LocKey:       "loc-key",
+			LocArgs:      []string{"arg1", "arg2"},
+			LaunchImage:  "launch.png",
+		},
 	}
 
 	payloadSize := 256
@@ -245,14 +247,16 @@ func TestAlertBodyMarshalWithCustomFields(t *testing.T) {
 	}
 
 	p := Payload{
-		AlertText:        "Testing this payload",
 		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
-		ActionLocKey:     "act-loc-key",
-		LocKey:           "loc-key",
-		LaunchImage:      "launch.png",
+		AlertBody: APSAlertBody{
+			Body:         "Testing this payload",
+			ActionLocKey: "act-loc-key",
+			LocKey:       "loc-key",
+			LaunchImage:  "launch.png",
+		},
 	}
 
 	payloadSize := 256
@@ -278,13 +282,15 @@ func TestAlertBodyMarshalWithCustomFields(t *testing.T) {
 
 func TestAlertBodyMarshalTruncate(t *testing.T) {
 	p := Payload{
-		AlertText: "Testing this payload with a really long message that should " +
-			"cause the payload to be truncated yay and stuff blah blah blah blah blah blah " +
-			"and some more text to really make this much bigger and stuff",
 		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
-		LaunchImage:      "launch.png",
+		AlertBody: APSAlertBody{
+			Body: "Testing this payload with a really long message that should " +
+				"cause the payload to be truncated yay and stuff blah blah blah blah blah blah " +
+				"and some more text to really make this much bigger and stuff",
+			LaunchImage: "launch.png",
+		},
 	}
 
 	payloadSize := 256
@@ -313,17 +319,19 @@ func TestAlertBodyMarshalTruncateWithCustomFields(t *testing.T) {
 	}
 
 	p := Payload{
-		AlertText: "Testing this payload with a bunch of text that should get truncated " +
-			"so truncate this already please yes thank you blah blah blah blah blah blah " +
-			"plus some more text",
 		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
-		ActionLocKey:     "act-loc-key",
-		LocKey:           "loc-key",
-		LocArgs:          []string{"arg1", "arg2"},
-		LaunchImage:      "launch.png",
+		AlertBody: APSAlertBody{
+			Body: "Testing this payload with a bunch of text that should get truncated " +
+				"so truncate this already please yes thank you blah blah blah blah blah blah " +
+				"plus some more text",
+			ActionLocKey: "act-loc-key",
+			LocKey:       "loc-key",
+			LocArgs:      []string{"arg1", "arg2"},
+			LaunchImage:  "launch.png",
+		},
 	}
 
 	payloadSize := 256
@@ -374,12 +382,14 @@ func TestAlertBodyMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T)
 	}
 
 	p := Payload{
-		AlertText:        "Testing this payload",
 		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
-		LaunchImage:      "launch.png",
+		AlertBody: APSAlertBody{
+			Body:        "Testing this payload",
+			LaunchImage: "launch.png",
+		},
 	}
 
 	payloadSize := 256
@@ -456,14 +466,16 @@ func BenchmarkAlertBodyMarshalTruncate256WithCustomFields(b *testing.B) {
 	}
 
 	p := Payload{
-		AlertText: "Testing this payload with a bunch of text that should get truncated " +
-			"so truncate this already please yes thank you blah blah blah blah blah blah " +
-			"plus some more text",
 		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
-		LaunchImage:      "launch.png",
+		AlertBody: APSAlertBody{
+			Body: "Testing this payload with a bunch of text that should get truncated " +
+				"so truncate this already please yes thank you blah blah blah blah blah blah " +
+				"plus some more text",
+			LaunchImage: "launch.png",
+		},
 	}
 
 	b.ResetTimer()
@@ -484,14 +496,19 @@ func BenchmarkAlertBodyMarshalTruncate1024WithCustomFields(b *testing.B) {
 	}
 
 	p := Payload{
-		AlertText: "Testing this payload with a bunch of text that should get truncated " +
-			"so truncate this already please yes thank you blah blah blah blah blah blah " +
-			"plus some more text",
 		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
-		LaunchImage:      "launch.png",
+		AlertBody: APSAlertBody{
+			Body: "Testing this payload with a bunch of text that should get truncated " +
+				"so truncate this already please yes thank you blah blah blah blah blah blah " +
+				"plus some more text",
+			ActionLocKey: "act-loc-key",
+			LocKey:       "loc-key",
+			LocArgs:      []string{"arg1", "arg2"},
+			LaunchImage:  "launch.png",
+		},
 	}
 
 	b.ResetTimer()

--- a/payload_test.go
+++ b/payload_test.go
@@ -8,7 +8,7 @@ import (
 func TestSimpleMarshal(t *testing.T) {
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		Category:         "TEST_CATEGORY",
@@ -25,7 +25,7 @@ func TestSimpleMarshal(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"category\":\"TEST_CATEGORY\",\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
@@ -34,7 +34,6 @@ func TestSimpleMarshal(t *testing.T) {
 func TestBadge0ShouldOmitBadge(t *testing.T) {
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            0,
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		Category:         "TEST_CATEGORY",
@@ -51,33 +50,7 @@ func TestBadge0ShouldOmitBadge(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
-	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
-	}
-}
-
-func TestBadgeLessThan0ShouldBadgeMinus1(t *testing.T) {
-	p := Payload{
-		AlertText:        "Testing this payload",
-		Badge:            -5,
-		ContentAvailable: 1,
-		Sound:            "test.aiff",
-		Category:         "TEST_CATEGORY",
-	}
-
-	payloadSize := 256
-
-	json, err := p.Marshal(payloadSize)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(json) > payloadSize {
-		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
-	}
-
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":-1,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"category\":\"TEST_CATEGORY\",\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
@@ -96,7 +69,7 @@ func TestSimpleMarshalWithCustomFields(t *testing.T) {
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -113,7 +86,7 @@ func TestSimpleMarshalWithCustomFields(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1},\"arr\":[\"a\",2],\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload\",\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"},\"arr\":[\"a\",2],\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
 	}
@@ -124,7 +97,7 @@ func TestSimpleMarshalTruncate(t *testing.T) {
 		AlertText: "Testing this payload with a really long message that should " +
 			"cause the payload to be truncated yay and stuff blah blah blah blah blah blah " +
 			"and some more text to really make this much bigger and stuff",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 	}
@@ -140,7 +113,7 @@ func TestSimpleMarshalTruncate(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and some more text to really make this much...\",\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and some more text to really make this much...\",\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
 	}
@@ -161,7 +134,7 @@ func TestSimpleMarshalTruncateWithCustomFields(t *testing.T) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -179,7 +152,7 @@ func TestSimpleMarshalTruncateWithCustomFields(t *testing.T) {
 	}
 
 	expectedJson := "{\"aps\":{\"alert\":\"Testing this payload with a bunch of text that should get truncated " +
-		"so truncate this already please yes thank you...\",\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}," +
+		"so truncate this already please yes thank you...\",\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}," +
 		"\"arr\":[\"a\",2],\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
@@ -216,7 +189,7 @@ func TestSimpleMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T) {
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -233,7 +206,7 @@ func TestSimpleMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T) {
 func TestAlertBodyMarshal(t *testing.T) {
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Category:         "TEST_CATEGORY",
 		Sound:            "test.aiff",
@@ -254,7 +227,7 @@ func TestAlertBodyMarshal(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\",\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"category\":\"TEST_CATEGORY\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\",\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"category\":\"TEST_CATEGORY\",\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
 		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
@@ -273,7 +246,7 @@ func TestAlertBodyMarshalWithCustomFields(t *testing.T) {
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -295,11 +268,11 @@ func TestAlertBodyMarshalWithCustomFields(t *testing.T) {
 
 	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\"," +
 		"\"launch-image\":\"launch.png\"}," +
-		"\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1},\"arr\":[\"a\",2]," +
+		"\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"},\"arr\":[\"a\",2]," +
 		"\"num\":55,\"obj\":{\"obja\":\"a\",\"objb\":\"b\"},\"str\":\"string\"}"
 
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 
@@ -308,7 +281,7 @@ func TestAlertBodyMarshalTruncate(t *testing.T) {
 		AlertText: "Testing this payload with a really long message that should " +
 			"cause the payload to be truncated yay and stuff blah blah blah blah blah blah " +
 			"and some more text to really make this much bigger and stuff",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		LaunchImage:      "launch.png",
@@ -325,9 +298,9 @@ func TestAlertBodyMarshalTruncate(t *testing.T) {
 		t.Error(fmt.Sprintf("Expected payload to be less than %v but was %v", payloadSize, len(json)))
 	}
 
-	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and so...\",\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}}"
+	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this payload with a really long message that should cause the payload to be truncated yay and stuff blah blah blah blah blah blah and so...\",\"launch-image\":\"launch.png\"},\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}}"
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 
@@ -343,7 +316,7 @@ func TestAlertBodyMarshalTruncateWithCustomFields(t *testing.T) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -365,10 +338,10 @@ func TestAlertBodyMarshalTruncateWithCustomFields(t *testing.T) {
 	}
 
 	expectedJson := "{\"aps\":{\"alert\":{\"body\":\"Testing this ...\",\"action-loc-key\":\"act-loc-key\",\"loc-key\":\"loc-key\"," +
-		"\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"sound\":\"test.aiff\",\"content-available\":1}," +
+		"\"loc-args\":[\"arg1\",\"arg2\"],\"launch-image\":\"launch.png\"},\"badge\":2,\"content-available\":1,\"sound\":\"test.aiff\"}," +
 		"\"arr\":[\"a\",2],\"arr2\":[\"a\",2],\"num\":55,\"str\":\"string\"}"
 	if string(json) != expectedJson {
-		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, json))
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
 	}
 }
 
@@ -402,7 +375,7 @@ func TestAlertBodyMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T)
 
 	p := Payload{
 		AlertText:        "Testing this payload",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -432,7 +405,7 @@ func BenchmarkSimpleMarshalTruncate256WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -459,7 +432,7 @@ func BenchmarkSimpleMarshalTruncate1024WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -486,7 +459,7 @@ func BenchmarkAlertBodyMarshalTruncate256WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,
@@ -514,7 +487,7 @@ func BenchmarkAlertBodyMarshalTruncate1024WithCustomFields(b *testing.B) {
 		AlertText: "Testing this payload with a bunch of text that should get truncated " +
 			"so truncate this already please yes thank you blah blah blah blah blah blah " +
 			"plus some more text",
-		Badge:            2,
+		Badge:            NewBadgeNumber(2),
 		ContentAvailable: 1,
 		Sound:            "test.aiff",
 		CustomFields:     customFields,


### PR DESCRIPTION
(Note: includes `BadgeNumber` changes from #8 )

iOS 8 brought with it a [max 2 kilobyte message size](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1) (up from 256 bytes). That's reflected in this pull request.

iOS 8.2 adds a few more fields as well. They are:
```
- title
- title-loc-key
- title-loc-args
```

This also makes `APSAlertBody` public, puts it in Payload, and changes the simple check to simply look at  `Payload.AlertText == ""`.

Further, payload truncation works on `Payload.AlertBody.Body` for non-simple messages, and rearranges a couple fields. 

I'm not trying to take over your code :) If you'd rather I move this to a new repo (with credit), I'd be happy to do so. This is all in preparation for a server wrapper I'm adding around this and https://github.com/alexjlockwood/gcm