### PR TITLE
use exported (*Payload).Marshal instead of internal (*Payload).marshalAlertBodyPayload

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -346,7 +346,7 @@ func (c *APNSConnection) bufferPayload(idPayloadObj *idPayload) {
 		c.Disconnect()
 		return
 	}
-	payloadBytes, err := idPayloadObj.Payload.marshalAlertBodyPayload(c.config.MaxPayloadSize)
+	payloadBytes, err := idPayloadObj.Payload.Marshal(c.config.MaxPayloadSize)
 	if err != nil {
 		fmt.Printf("Failed to marshall payload %v : %v\n", idPayloadObj.Payload, err)
 		c.Disconnect()


### PR DESCRIPTION
since the encoding logic was calling marshalAlertBodyPayload directly, simple payloads were ignored and being sent as ```"alert": {}```, instead of ```"alert": "foobar"```