### PR TITLE
Fix connection marshalling of payload

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -346,7 +346,7 @@ func (c *APNSConnection) bufferPayload(idPayloadObj *idPayload) {
 		c.Disconnect()
 		return
 	}
-	payloadBytes, err := idPayloadObj.Payload.marshalAlertBodyPayload(c.config.MaxPayloadSize)
+	payloadBytes, err := idPayloadObj.Payload.Marshal(c.config.MaxPayloadSize)
 	if err != nil {
 		fmt.Printf("Failed to marshall payload %v : %v\n", idPayloadObj.Payload, err)
 		c.Disconnect()


### PR DESCRIPTION
Connection was always calling `marshalAlertBodyPayload` instead of `Marshal`, which would never marshal a simple payload, as determined by `IsSimple()`. Was causing `EOF` errors from APNS.