### PR TITLE
fix disconnect deadlock

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -342,11 +342,11 @@ func (c *APNSConnection) sendListener(errCloseChannel chan *AppleError) {
 func (c *APNSConnection) bufferPayload(idPayloadObj *idPayload) error {
 	token, err := hex.DecodeString(idPayloadObj.Payload.Token)
 	if err != nil {
-		return fmt.Errorf("Error decoding token for payload %v\n", idPayloadObj.Payload)
+		return fmt.Errorf("Error decoding token for payload %+v : %v\n", idPayloadObj.Payload, err)
 	}
 	payloadBytes, err := idPayloadObj.Payload.Marshal(c.config.MaxPayloadSize)
 	if err != nil {
-		return fmt.Errorf("Error marshalling payload %v : %v\n", idPayloadObj.Payload, err)
+		return fmt.Errorf("Error marshalling payload %+v : %v\n", idPayloadObj.Payload, err)
 	}
 
 	//acquire lock to tcp buffer to do length checking, buffer writing,


### PR DESCRIPTION
bufferPayload used to grab inFlightBufferLock at the beginning. if either token decoding or payload marshalling failed, Disconnect would be unable to grab it and deadlock. this patch delays grabbing the lock until we know we want to begin mutating the buffer. deferred unlocking of inFlightBufferLock to try and prevent future deadlock issues.

i also refactored bufferPayload to stop disconnecting and instead return errors, since i don't see a reason why we would disconnect our APNS socket due to a bad message that is never sent. we now log the bad message and continue to the next payload.