### PR TITLE
Fix empty object sent in "alert" field of badge-only notifications.

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -83,7 +83,7 @@ func (p *Payload) Marshal(maxPayloadSize int) ([]byte, error) {
 
 //Whether or not to use simple aps format or not
 func (p *Payload) isSimple() bool {
-	return p.AlertText != ""
+	return p.AlertBody.Body == ""
 }
 
 //Helper method to generate a json compatible map with aps key + custom fields

--- a/payload_test.go
+++ b/payload_test.go
@@ -400,6 +400,24 @@ func TestAlertBodyMarshalThrowErrorIfPayloadTooBigWithCustomFields(t *testing.T)
 	}
 }
 
+func TestBadgeOnlyMarshal(t *testing.T) {
+	p := Payload{
+		Badge: NewBadgeNumber(2),
+	}
+
+	payloadSize := 256
+
+	json, err := p.Marshal(payloadSize)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedJson := "{\"aps\":{\"badge\":2}}"
+	if string(json) != expectedJson {
+		t.Error(fmt.Sprintf("Expected %v but got %v", expectedJson, string(json)))
+	}
+}
+
 func BenchmarkSimpleMarshalTruncate256WithCustomFields(b *testing.B) {
 	customFields := map[string]interface{}{
 		"num": 55,


### PR DESCRIPTION
Notifications containing no alert text were serialized as extended alerts,
with '"alert": {}' in the output. This wasted space and could have surprised
clients expecting the field to contain a string or be omitted entirely.

Fixed by treating alerts with no text as simple alerts, which do omit the
alert field when empty.

Includes regression test.